### PR TITLE
évite d'avoir deux titres sur les pages de blog

### DIFF
--- a/numerique_gouv/templates/numerique_gouv/blog_index_page.html
+++ b/numerique_gouv/templates/numerique_gouv/blog_index_page.html
@@ -10,11 +10,6 @@
 
 <div class="fr-container fr-pt-4w">
   {% include "content_manager/blocks/breadcrumbs.html" %}
-  {% if not page.header_with_title %}
-  <h1>
-    {{ page.title }}
-  </h1>
-  {% endif %}
 
   {% if current_category.description %}
   {{ current_category.description|richtext }}


### PR DESCRIPTION
closes #140 
Due à un problème de mise à jour de Sites-Faciles