### PR TITLE
fix alt for image

### DIFF
--- a/numerique_gouv/templates/numerique_gouv/blocks/numeric_direction_card.html
+++ b/numerique_gouv/templates/numerique_gouv/blocks/numeric_direction_card.html
@@ -17,7 +17,7 @@
   </div>
   <div class="fr-card__header">
     <div style="display: flex; align-items: center;height: 100%;">
-      {% image value.image original class="fr-responsive-img" alt="{{ value.alt }}" data-fr-js-ratio="true" %}
+      <img src="{{ value.image.url }}" class="fr-responsive-img" alt="{{ value.alt|default_if_none:"" }}" data-fr-js-ratio="true">    
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 🎯 Objectif

les images des ministère avaient une balise alt qui n'affichait pas la valeur du champs alt en base
## 🔍 Implémentation

- _Une liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
