### PR TITLE
feat: add nginx with access control rules

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,4 @@
 https://github.com/Scalingo/apt-buildpack.git
 https://github.com/Scalingo/python-buildpack.git
 https://github.com/Scalingo/locale-buildpack.git
+https://github.com/Scalingo/nginx-buildpack.git

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 postdeploy: python manage.py migrate && python manage.py import_dsfr_pictograms && python manage.py import_page_templates && python manage.py update_index
-web: gunicorn config.wsgi --log-file -
+web: (bin/run &) && gunicorn config.wsgi -b 0.0.0.0:$CMS_PORT --log-file -

--- a/serveurs.conf.erb
+++ b/serveurs.conf.erb
@@ -1,0 +1,13 @@
+server {
+    server_name localhost;
+    listen <%= ENV['PORT'] %>;
+
+    location / {
+        <%= ENV['NGINX_API_ACCESS_RULES'] %>
+
+        proxy_set_header  X-Remote-Address $remote_addr;
+        proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://localhost:<%= ENV['CMS_PORT'] %>;
+        proxy_redirect default;
+    }
+}


### PR DESCRIPTION
## 🎯 Objectif

Permet d'appliquer des restrictions d'accès à l'application (en particulier par IPs)

## 🔍 Implémentation

Ajout d'un buildpack scalingo nginx avec sa configuration

## ⚠️ Informations supplémentaires

Il faut ajouter la variable d'env CMS_PORT en obligatoire.
En facultatif, il y a la variable NGINX_API_ACCESS_RULES
