### PR TITLE
Add source map for swiper-bundle.min.js

### DIFF
--- a/static/lib/swiperjs/swiper-bundle.min.js.map
+++ b/static/lib/swiperjs/swiper-bundle.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":[],"names":[],"mappings":"","file":"swiper-bundle.min.js"}


### PR DESCRIPTION
 Problem

  The deployment was failing during collectstatic with WhiteNoise's CompressedManifestStaticFilesStorage
  because the swiper.js file referenced a source map file (swiper-bundle.min.js.map) that didn't exist.

  Solution

  Added an empty source map file to satisfy WhiteNoise's file reference validation. This allows the static
  files collection to complete successfully without removing the source map reference from the original
  Swiper library file.

  Changes

  - Created static/lib/swiperjs/swiper-bundle.min.js.map with minimal valid source map content

  This fix ensures compatibility with WhiteNoise in production while maintaining the integrity of
  third-party library files.

